### PR TITLE
Turned off back buttons

### DIFF
--- a/demo_qd.R
+++ b/demo_qd.R
@@ -26,7 +26,7 @@ demoQDSidebarUI <- function(id) {
 demoQDBodyUI <- function(id){
   ns <- shiny::NS(id)
   shiny::tagList(
-    shinycssloaders::withSpinner(shiny::uiOutput(ns("qd_results"))),
+    shiny::uiOutput(ns("qd_results")),
     currentImageUI(ns("demo_qd"))
   )
 }

--- a/inner.R
+++ b/inner.R
@@ -37,8 +37,9 @@ innerUI <- function(id) {
                                                                                        ns = shiny::NS(id),
                                                                                        shiny::div(id = "autonomous",
                                                                                                   shiny::includeHTML("www/demo_preview.html"),
-                                                                                                  shiny::fluidRow(shiny::column(width = 3, shiny::actionButton(ns("demo_preview_back_button"), "Back")), 
-                                                                                                                  shiny::column(width = 9, align = "right", shiny::actionButton(ns("demo_preview_next_button"), "Next")))
+                                                                                                  shiny::fluidRow(
+                                                                                                    # shiny::column(width = 3, shiny::actionButton(ns("demo_preview_back_button"), "Back")), 
+                                                                                                    shiny::column(width = 9, shiny::actionButton(ns("demo_preview_next_button"), "Next")))
                                                                                        ),
                                                                ),
                                                                
@@ -50,8 +51,9 @@ innerUI <- function(id) {
                                                                                                                  help_text = "Estimate writer profiles from the known writing samples and fit a statistical model to the writer profiles.",
                                                                                                                  module = demoKnownSidebarUI(ns("demo_known")),
                                                                                                                  break_after_module = TRUE),
-                                                                                                  shiny::fluidRow(shiny::column(width = 3, shiny::actionButton(ns("demo_known_back_button"), "Back")), 
-                                                                                                                  shiny::column(width = 9, align = "right", shiny::actionButton(ns("demo_known_next_button"), "Next")))
+                                                                                                  shiny::fluidRow(
+                                                                                                    # shiny::column(width = 3, shiny::actionButton(ns("demo_known_back_button"), "Back")), 
+                                                                                                    shiny::column(width = 9, shiny::actionButton(ns("demo_known_next_button"), "Next")))
                                                                                        ),
                                                                ),
                                                                
@@ -63,8 +65,9 @@ innerUI <- function(id) {
                                                                                                                  help_text = "Estimate writer profiles from the questioned documents. Use the statistical model to estimate the posterior probabilities that each POI wrote a questioned document.",
                                                                                                                  module = demoQDSidebarUI(ns("demo_qd")),
                                                                                                                  break_after_module = TRUE),
-                                                                                                  shiny::fluidRow(shiny::column(width = 3, shiny::actionButton(ns("demo_qd_back_button"), "Back")),
-                                                                                                                  shiny::column(width = 9, align = "right", shiny::actionButton(ns("demo_qd_next_button"), "Finish")))
+                                                                                                  shiny::fluidRow(
+                                                                                                    # shiny::column(width = 3, shiny::actionButton(ns("demo_qd_back_button"), "Back")),
+                                                                                                    shiny::column(width = 9, shiny::actionButton(ns("demo_qd_next_button"), "Finish")))
                                                                                        ),
                                                                ),
                         

--- a/rsconnect/shinyapps.io/csafe/handwriterAppDemo.dcf
+++ b/rsconnect/shinyapps.io/csafe/handwriterAppDemo.dcf
@@ -5,7 +5,7 @@ account: csafe
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 12397523
-bundleId: 8943296
+bundleId: 8968573
 url: https://csafe.shinyapps.io/handwriterAppDemo/
 version: 1
 asMultiple: FALSE


### PR DESCRIPTION
The back buttons currently cause unexpected behavior: the current image displayed on the Known and QD pages doesn't reset as expected.

I turned off the back buttons until I have time to figure out how to reset the current image.